### PR TITLE
Simplify interface and PyFilesystem usage

### DIFF
--- a/environment.dev.yml
+++ b/environment.dev.yml
@@ -6,9 +6,11 @@ dependencies:
  - dask
  - flake8
  - fs-s3fs
+ - isort
  - joblib
  - jupyterlab
  - mypy
  - pytest
  - pip:
+   - autopep8
    - lz4

--- a/examples/example_3.py
+++ b/examples/example_3.py
@@ -66,24 +66,20 @@ def compute_with_graphchain(dsk, skipkeys):
             result = dsk.compute(
                 compression=True,
                 no_cache_keys=skipkeys,
-                cachedir=cachedir,
-                persistency="local",
-                s3bucket="")
+                cachedir=cachedir)
             return result
     except GraphchainCompressionMismatch:
         print("[ERROR] Hashchain compression option mismatch.")
 
 
 def compute_with_graphchain_s3(dsk, skipkeys):
-    cachedir = "__hashchain__"
+    cachedir = "s3://graphchain-test-bucket/__hashchain__"
     try:
         with dask.set_options(delayed_optimize=optimize):
             result = dsk.compute(
                 compression=True,
                 no_cache_keys=skipkeys,
-                cachedir=cachedir,
-                persistency="s3",
-                s3bucket="graphchain-test-bucket")
+                cachedir=cachedir)
             return result
     except GraphchainCompressionMismatch:
         print("[ERROR] Hashchain compression option mismatch.")

--- a/graphchain/__init__.py
+++ b/graphchain/__init__.py
@@ -1,8 +1,7 @@
 from .graphchain import optimize, get
-from .errors import (InvalidPersistencyOption, GraphchainCompressionMismatch,
-                     GraphchainPicklingError)
+from .errors import GraphchainCompressionMismatch, GraphchainPicklingError
 
 __all__ = [
-    "optimize", "get", "InvalidPersistencyOption",
+    "optimize", "get",
     "GraphchainCompressionMismatch", "GraphchainPicklingError"
 ]

--- a/graphchain/errors.py
+++ b/graphchain/errors.py
@@ -4,15 +4,6 @@ Module containing basic exceptions used trhoughout the
 """
 
 
-class InvalidPersistencyOption(ValueError):
-    """
-    Simple exception that is raised whenever the persistency
-    option in the `optimize` function does not match the one
-    of the supported options "local" or "s3".
-    """
-    pass
-
-
 class GraphchainCompressionMismatch(EnvironmentError):
     """
     Simple exception that is raised whenever the compression


### PR DESCRIPTION
- [x] `cachedir`, `persistency`, and `s3bucket` have been merged into a single argument `cachedir`, which is passed as a FS URL directly to `fs.open_fs` [1].
- [x] `compression` is now `compress` to match the `joblib.Memory` interface. In the future, we could support more than `bool`s, similar to `joblib.Memory`.
- [x] Graphchain now uses `dask.core.toposort` to get all keys sorted topologically.

[1] https://pyfilesystem2.readthedocs.io/en/latest/openers.html