### PR TITLE
Two simple fixed for use with dask.distributed

### DIFF
--- a/graphchain/core.py
+++ b/graphchain/core.py
@@ -455,9 +455,6 @@ def get(
         The computed values corresponding to the given keys.
     """
     cached_dsk = optimize(dsk, keys, skip_keys=skip_keys, location=location)
-    scheduler = \
-        scheduler or \
-        dask.config.get('get', None) or \
-        dask.config.get('scheduler', None) or \
-        dask.get
-    return scheduler(cached_dsk, keys)
+    schedule = dask.base.get_scheduler(scheduler=scheduler) or dask.get
+ 
+    return schedule(cached_dsk, keys)

--- a/graphchain/core.py
+++ b/graphchain/core.py
@@ -13,7 +13,7 @@ import dask
 import fs
 import fs.base
 import joblib
-from dask.highlevelgraph import HighLevelGraph
+from dask.highlevelgraph import HighLevelGraph, Layer
 
 from .utils import get_size, str_to_posix_fully_portable_filename
 
@@ -29,6 +29,15 @@ def hlg_setitem(self: HighLevelGraph, key: Hashable, value: Any) -> None:
 # Monkey patch HighLevelGraph to add a missing `__setitem__` method.
 if not hasattr(HighLevelGraph, '__setitem__'):
     HighLevelGraph.__setitem__ = hlg_setitem
+
+def layer_setitem(self: Layer, key: Hashable, value: Any) -> None:
+    """Set a Layer computation."""
+    self.mapping[key] = value
+
+
+# Monkey patch Layer to add a missing `__setitem__` method.
+if not hasattr(Layer, '__setitem__'):
+    Layer.__setitem__ = layer_setitem
 
 
 logger = logging.getLogger(__name__)

--- a/graphchain/core.py
+++ b/graphchain/core.py
@@ -14,6 +14,7 @@ import fs
 import fs.base
 import joblib
 from dask.highlevelgraph import HighLevelGraph, Layer
+from dask.base import tokenize
 
 from .utils import get_size, str_to_posix_fully_portable_filename
 
@@ -155,8 +156,20 @@ class CachedComputation:
                 self._subs_tasks_with_src(x) for x in computation]
         elif dask.core.istask(computation):
             # This computation is a task.
-            src = joblib.func_inspect.get_func_code(computation[0])[0]
-            computation = (src,) + computation[1:]
+            func = computation[0]
+            extr = tuple()
+            if isinstance(func,functools.partial):
+                # If the function is a func.partial (as done with dask.array), we resolve.
+                extr = (tokenize(func.args), tokenize(func.keywords), )
+                func = func.func
+            src = joblib.func_inspect.get_func_code(func)[0]
+
+            # As dask.array uses SubgraphCallables with a random key, need to remove those
+            # in order to keep deterministic. Potentially this will cause some new problems.
+            sgc = dask.optimization.SubgraphCallable
+            if isinstance(func,sgc):
+                src = tokenize(func.inkeys)+tokenize(func.outkey)
+            computation = (src,) + computation[1:] + extr
         return computation
 
     def compute_hash(self) -> str:


### PR DESCRIPTION
Trying to run graphchain with dask distributed version '2021.10.0' with

```
from dask.distributed import Client, LocalCluster
cluster = LocalCluster()
client = Client(cluster)
```

for the _graphchain.get_ example

```
import dask
import graphchain
import pandas as pd

def create_dataframe(num_rows, num_cols):
    print('Creating DataFrame...')
    return pd.DataFrame(data=[range(num_cols)]*num_rows)

def complicated_computation(df, num_quantiles):
    print('Running complicated computation on DataFrame...')
    return df.quantile(q=[i / num_quantiles for i in range(num_quantiles)])

def summarise_dataframes(*dfs):
    print('Summing DataFrames...')
    return sum(df.sum().sum() for df in dfs)

dsk = {
    'df_a': (create_dataframe, 10_000, 1000),
    'df_b': (create_dataframe, 10_000, 1000),
    'df_c': (complicated_computation, 'df_a', 2048),
    'df_d': (complicated_computation, 'df_b', 2048),
    'result': (summarise_dataframes, 'df_c', 'df_d')
}

graphchain.get(dsk, 'result')
```
requires commit https://github.com/cbyrohl/graphchain/commit/5f3ec55a16b251b604df00b0d6b02104a09b0c4e to properly obtain the scheduler.

Similarly for _graphchain.optimize_, we need _\_\_setitem\_\__ for dask Layer in the example

```
import dask
import dask.distributed
import graphchain
import dask.array as da

arr = da.arange(int(1e3))
arr = arr.sum()
with dask.distributed.Client(address=cluster):
    with dask.config.set(array_optimize=graphchain.optimize):
        s = arr.compute()
```
through commit https://github.com/cbyrohl/graphchain/commit/e59cd714435544d11cac307636061fd3139ca176 .
